### PR TITLE
Fix YAML doc separator indent

### DIFF
--- a/infra/deployment.yml
+++ b/infra/deployment.yml
@@ -200,7 +200,7 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9000
-  ---
+---
 # ClusterIP service exposing LLM API on port 9000
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
- fix YAML indentation in Kubernetes configuration to ensure parser compatibility

## Testing
- `bash run_tests.sh` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863c02bd13083318e716e5cb5ae5372