### PR TITLE
Fix serve listen flag for frontend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,4 +10,8 @@ RUN npm install -g serve
 COPY . .
 
 RUN echo "Using API: $REACT_APP_API_URL" && npm run build
-CMD ["serve", "-s", "build", "--listen", "0.0.0.0:3000"]
+# 'serve' 14+ expects a scheme prefix for the --listen argument. Without the
+# "tcp://" prefix the value is parsed as a URL and results in an error like
+# "Unknown --listen endpoint scheme". Prefix with "tcp://" so the frontend can
+# bind correctly on port 3000 when deployed in Kubernetes.
+CMD ["serve", "-s", "build", "--listen", "tcp://0.0.0.0:3000"]


### PR DESCRIPTION
## Summary
- update the frontend Dockerfile to pass the expected `tcp://` scheme to `serve --listen`

## Testing
- `bash run_tests.sh` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ecb75d1c8331a5ba595538dbc8c6