### PR TITLE
Fix minikube frontend API URL

### DIFF
--- a/infra/deployment.yml
+++ b/infra/deployment.yml
@@ -353,7 +353,7 @@ spec:
         imagePullPolicy: IfNotPresent
         env:
         - name: REACT_APP_API_URL
-          value: http://backend:8000
+          value: http://localhost:8000
         ports:
         - containerPort: 3000
 

--- a/infra/start-minikube.sh
+++ b/infra/start-minikube.sh
@@ -33,7 +33,8 @@ declare -a IMAGES=(
   "backend:latest ../backend"
   "worker:latest ../worker"
   "rule-runner:latest ../runner"
-  "frontend:latest --build-arg REACT_APP_API_URL=http://backend:8000 ../frontend"
+  # Build the frontend so the generated JS calls the backend via the port-forward on localhost
+  "frontend:latest --build-arg REACT_APP_API_URL=http://localhost:8000 ../frontend"
 #  "llm-service:latest ../llm_service"
 )
 # Iterate over each image entry, build and load into Minikube


### PR DESCRIPTION
## Summary
- update Minikube helper to build the frontend using localhost for the API URL
- update Kubernetes deployment to use the same API URL

## Testing
- `bash run_tests.sh` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f91188448331b5584ae0638ae714