### PR TITLE
Fix CORS error for dashboard API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -48,7 +48,7 @@ app = FastAPI()
 # Enable CORS to allow the frontend (e.g. React) to communicate with this API.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=["http://localhost:3000"],  # allow local frontend
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- restrict backend CORS policy to allow the React dev origin

## Testing
- `bash run_tests.sh` *(fails: `docker-compose` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fd9b34588331a8343126ef39e569