### PR TITLE
Fix CORS configuration

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -48,7 +48,7 @@ app = FastAPI()
 # Enable CORS to allow the frontend (e.g. React) to communicate with this API.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],  # allow local frontend
+    allow_origins=["*"],  # allow all origins for development
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/llm_service/main.py
+++ b/llm_service/main.py
@@ -12,7 +12,7 @@ app = FastAPI(debug=True)
 # enable CORS for the frontend
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],  # or ['*'] to allow all origins
+    allow_origins=["*"],  # allow all origins for development
     allow_methods=["*"],  # allow GET, POST, OPTIONS, etc.
     allow_headers=["*"],  # allow all headers
     allow_credentials=True,


### PR DESCRIPTION
## Summary
- relax CORS rules in backend and LLM service for development

## Testing
- `bash ./run_tests.sh` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640180149c8331985eaf496148e170