### PR TITLE
Fix missing Integer import in backend models

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,5 @@
 import uuid
-from sqlalchemy import Column, String, Text, ForeignKey, DateTime, JSON
+from sqlalchemy import Column, String, Text, ForeignKey, DateTime, JSON, Integer
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship


### PR DESCRIPTION
## Summary
- import `Integer` type in backend models

## Testing
- `bash run_tests.sh` *(fails: `docker-compose` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640bd7334c83318a4538b2382e0a88