### PR TITLE
Adjust CORS configuration

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -46,9 +46,15 @@ from app.schemas import DashboardKPI, DashboardTrendItem, DashboardTopViolations
 app = FastAPI()
 
 # Enable CORS to allow the frontend (e.g. React) to communicate with this API.
+origins_env = os.getenv("CORS_ORIGINS", "*")
+if origins_env == "*":
+    origins = ["*"]
+else:
+    origins = [o.strip() for o in origins_env.split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # allow all origins for development
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- make allowed CORS origins configurable via a `CORS_ORIGINS` env var

## Testing
- `pytest -q` *(fails: OperationalError: could not translate host name "postgres" to address)*

------
https://chatgpt.com/codex/tasks/task_e_68641159916c8331af84e3d5419e4669