### PR TITLE
Fix dashboard SQL schema mismatch

### DIFF
--- a/backend/initdb/03_add_rules_fields.sql
+++ b/backend/initdb/03_add_rules_fields.sql
@@ -5,8 +5,8 @@ DROP TABLE IF EXISTS rule_results CASCADE;
 CREATE TABLE IF NOT EXISTS rule_results (
   -- Unique identifier for each rule result entry
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  -- Timestamp indicating when the rule was last executed
-  last_run TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  -- Timestamp indicating when the rule violation or check was detected
+  detected_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
   -- Foreign key linking to the specific rule that generated this result; cascades deletes to maintain referential integrity
   rule_id UUID NOT NULL REFERENCES column_rules(id) ON DELETE CASCADE,
   -- JSONB column storing the detailed output or payload of the rule check

--- a/backend/initdb/seed_data.sql
+++ b/backend/initdb/seed_data.sql
@@ -150,9 +150,9 @@ INSERT INTO column_rules (db_connection_id, table_name, column_name, rule_name, 
 --     - errors: array of random error codes (integers) to simulate error details
 --     - duration_ms: randomized execution duration in milliseconds
 -- The CROSS JOIN LATERAL and generate_series create multiple such entries per rule to simulate multiple checks.
-INSERT INTO rule_results (last_run, rule_id, result)
+INSERT INTO rule_results (detected_at, rule_id, result)
 SELECT
-  NOW() - ((random() * 30) || ' days')::interval AS last_run,
+  NOW() - ((random() * 30) || ' days')::interval AS detected_at,
   cr.id AS rule_id,
   jsonb_build_object(
     'timestamp', to_char(NOW(), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),


### PR DESCRIPTION
## Summary
- align rule_results table schema with backend models
- update seed data to use `detected_at` column

## Testing
- `bash run_tests.sh` *(fails: `docker-compose` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686416db222c8331a7ce0c631a46e0e9