### PR TITLE
Add negative price rule and sample data

### DIFF
--- a/backend/initdb/seed_data.sql
+++ b/backend/initdb/seed_data.sql
@@ -135,7 +135,17 @@ INSERT INTO column_rules (db_connection_id, table_name, column_name, rule_name, 
         return {"error": str(e)}
     finally:
         cursor.close()
-''','medium','find negative prices','minutely');
+''','medium','find negative prices','minutely'),
+('848bdf25-427a-42c0-9739-e6926f0dd050','products','price','NegativePriceCheck','''def rule(connection):
+    try:
+        cursor = connection.cursor()
+        cursor.execute("SELECT id FROM products WHERE price < 0")
+        result = [row[0] for row in cursor.fetchall()]
+    except Exception as e:
+        result = {"error": str(e)}
+    finally:
+        cursor.close()
+''','medium','detect negative product prices','minutely');
 
 -- Insert simulated rule check results with failure status into the rule_results table.
 -- This uses a SELECT statement to generate multiple entries per rule with randomized timestamps and error details.

--- a/ecommerce-init-1/init.sql
+++ b/ecommerce-init-1/init.sql
@@ -92,8 +92,11 @@ INSERT INTO products (name, description, price)
 SELECT
   'Product '||i,
   'Description for product '||i,
-  round((random()*100 + 1)::numeric, 2)
-FROM generate_series(1,50) AS t(i);
+  CASE
+    WHEN i <= 10 THEN -round((random()*100 + 1)::numeric, 2)
+    ELSE round((random()*100 + 1)::numeric, 2)
+  END
+FROM generate_series(1,100) AS t(i);
 
 -- Insert 30 orders
 -- Purpose: Creates 30 orders, each linked to a random customer.


### PR DESCRIPTION
## Summary
- insert 100 products in ecommerce-init-1 with 10 negative prices
- add new Python rule to detect negative prices in backend seed data

## Testing
- `./run_tests.sh` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865031e21d483319f2242320933b046