### PR TITLE
Add inline comments across codebase

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,4 @@
+"""
+Backend package for the Valiax application.
+Contains the API, database models, and utilities.
+"""

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,3 @@
+"""
+Subpackage holding database models and CRUD logic for Valiax.
+"""

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,3 +1,5 @@
+"""CRUD helper functions for the Valiax backend."""
+
 from sqlalchemy.orm import Session
 from . import models, schemas
 from uuid import UUID

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,3 +1,5 @@
+"""Database engine and session management for the Valiax backend."""
+
 import os
 from dotenv import load_dotenv
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,3 +1,5 @@
+"""SQLAlchemy ORM models used by the Valiax backend."""
+
 import uuid
 from sqlalchemy import Column, String, Text, ForeignKey, DateTime, JSON, Integer
 from sqlalchemy.dialects.postgresql import UUID

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,3 +1,5 @@
+"""Pydantic schema definitions for API request and response models."""
+
 import datetime
 from pydantic import BaseModel
 from uuid import UUID

--- a/backend/tests/test_additional.py
+++ b/backend/tests/test_additional.py
@@ -1,4 +1,7 @@
-import importlib, sys
+"""Additional unit tests for the Valiax backend."""
+
+import importlib
+import sys
 from unittest.mock import MagicMock
 import runpy
 import uuid

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -1,3 +1,9 @@
+// ChatWidget.tsx
+//
+// Encapsulates the entire chat interface including history display and message
+// input. Communicates with the backend over WebSocket for live conversation
+// and can optionally attach column information for rule creation.
+
 import React, { useState, useRef, useEffect, FormEvent } from 'react';
 import {
   Box,

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -1,3 +1,8 @@
+// Dashboard.tsx
+//
+// React component responsible for displaying KPI tiles, trend charts and a list
+// of top violations for the currently selected database connection.
+
 import React, { useState, useEffect } from 'react';
 import ShowRuleModal from '../db/ShowRuleModal';
 import { useStore } from '../../store/store';

--- a/llm_service/llm.py
+++ b/llm_service/llm.py
@@ -1,19 +1,25 @@
-# llm_service/llm.py
+"""Minimal wrapper around a locally stored language model."""
+
 import os
 from ctransformers import AutoModelForCausalLM
 
-# Basisverzeichnis ist /app im Container
+# Determine the absolute path to the bundled GGUF model file. The container
+# mounts ``/app`` as the working directory, so ``__file__`` points inside that
+# directory.
 base_dir = os.path.dirname(__file__)
-# Modell liegt jetzt in llm_service/models/mistral3b.gguf
 model_path = os.path.join(base_dir, "models", "mistral3b.gguf")
 
-# Lade das GGUF-Modell lokal
+# Load the GGUF model once at import time so subsequent calls are fast. Setting
+# ``local_files_only=True`` avoids any attempt to download the model.
 model = AutoModelForCausalLM.from_pretrained(
     model_path,
     model_type="llama",
-    local_files_only=True
+    local_files_only=True,
 )
 
+
 def ask_llm(prompt: str) -> str:
-    # Call the model directly to get the complete response
+    """Return the model's response for ``prompt``."""
+
+    # Invoke the model directly to produce the completion text
     return model(prompt)

--- a/llm_service/main.py
+++ b/llm_service/main.py
@@ -1,3 +1,5 @@
+"""FastAPI service exposing the local language model over HTTP."""
+
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from llm import ask_llm

--- a/runner/run-rules.py
+++ b/runner/run-rules.py
@@ -1,3 +1,5 @@
+"""HTTP service that executes stored data quality rules in isolation."""
+
 import os
 import json
 import datetime


### PR DESCRIPTION
## Summary
- add module docstrings and inline comments throughout Python modules
- document dashboard and chat components in frontend
- describe rule listing script, LLM wrapper, and runner service

## Testing
- `bash run_tests.sh` *(fails: docker-compose not found)*
