### PR TITLE
Add rule details page and chart navigation

### DIFF
--- a/frontend/src/components/dashboard/RuleDetailPage.tsx
+++ b/frontend/src/components/dashboard/RuleDetailPage.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import Button from '@mui/material/Button';
+import type { ColumnRule } from '../../types';
+import { useStore } from '../../store/store';
+
+const RuleDetailPage: React.FC = () => {
+  const { ruleName } = useParams<{ ruleName: string }>();
+  const navigate = useNavigate();
+  const apiBase = process.env.REACT_APP_API_URL || '';
+  const dbName = useStore(state => state.selectedDatabaseName) || 'Unknown DB';
+  const [rule, setRule] = useState<ColumnRule | null>(null);
+
+  useEffect(() => {
+    if (!ruleName) return;
+    axios
+      .get<ColumnRule>(`${apiBase}/api/column-rules/${encodeURIComponent(ruleName)}`)
+      .then(res => setRule(res.data))
+      .catch(() => setRule(null));
+  }, [ruleName]);
+
+  if (!rule) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 space-y-4">
+      <Button variant="outlined" onClick={() => navigate(-1)}>
+        Back
+      </Button>
+      <h2 className="text-2xl font-bold">{rule.rule_name}</h2>
+      <div>
+        <p><strong>Database:</strong> {dbName}</p>
+        <p><strong>Table:</strong> {rule.table_name}</p>
+        <p><strong>Column:</strong> {rule.column_name}</p>
+        <p><strong>Interval:</strong> {rule.interval}</p>
+        <p><strong>Severity:</strong> {rule.severity}</p>
+        <p><strong>Description:</strong> {rule.description}</p>
+      </div>
+      <pre className="whitespace-pre-wrap border p-2 bg-gray-100">
+        {rule.rule_text}
+      </pre>
+    </div>
+  );
+};
+
+export default RuleDetailPage;

--- a/frontend/src/components/dashboard/TrendChart.tsx
+++ b/frontend/src/components/dashboard/TrendChart.tsx
@@ -3,6 +3,7 @@ import zoomPlugin from 'chartjs-plugin-zoom';
 import 'chartjs-adapter-date-fns';
 import React, { useMemo, useEffect, type MutableRefObject } from 'react';
 import { Line } from 'react-chartjs-2';
+import { useNavigate } from "react-router-dom";
 import type { DashboardTrendItem } from '../../types';
 import type { ChartOptions, ChartData } from 'chart.js';
 import Button from '@mui/material/Button';
@@ -62,6 +63,7 @@ const TrendChart: React.FC<Props> = ({
   const [initialStart, setInitialStart] = React.useState<string>('');
   const [initialEnd, setInitialEnd] = React.useState<string>('');
 
+  const navigate = useNavigate();
   useEffect(() => {
     // When trend data changes, determine a default date range to display.
     // The default range is the latest date in the data going back 90 days,
@@ -150,11 +152,10 @@ const TrendChart: React.FC<Props> = ({
           mode: 'x',
         },
         zoom: {
-          wheel: { enabled: true },
-          pinch: { enabled: true },
+          wheel: { enabled: false },
+          pinch: { enabled: false },
           drag: {
-            enabled: true,
-            backgroundColor: 'rgba(224,224,224,0.3)',
+            enabled: false,
           },
           mode: 'x',
           onZoomComplete({ chart }: { chart: any }) {
@@ -170,6 +171,13 @@ const TrendChart: React.FC<Props> = ({
       } as any,
       legend: { position: 'top' },
     },
+  onClick: (_e, els, chart) => {
+    if (els.length > 0) {
+      const idx = els[0].datasetIndex;
+      const ds = chart.data.datasets[idx];
+      if (ds && ds.label) navigate(`/rule/${encodeURIComponent(ds.label)}`);
+    }
+  }
   }), [rangeStart, rangeEnd]);
 
   return (
@@ -215,8 +223,13 @@ const TrendChart: React.FC<Props> = ({
           Reset timeframe
         </Button>
       </div>
-      {/* Line chart displaying the filtered trend data over the selected date range */}
-      <Line data={data} options={options} redraw ref={chartRef} />
+      <div className="relative h-96">
+        <Line data={data} options={options} redraw ref={chartRef} />
+        <div className="absolute top-2 right-2 space-x-1">
+          <Button size="small" variant="outlined" onClick={() => chartRef.current?.zoom(1.2)}>+</Button>
+          <Button size="small" variant="outlined" onClick={() => chartRef.current?.zoom(0.8)}>-</Button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -2,6 +2,8 @@ import 'bootstrap/dist/css/bootstrap.min.css'; // Import Bootstrap CSS for consi
 import './index.css'; // Import custom global CSS styles specific to this project
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import RuleDetailPage from "./components/dashboard/RuleDetailPage";
 import App from './App';
 
 // Create a root container for the React application.
@@ -16,10 +18,11 @@ root.render(
   // It activates additional checks and warnings for its descendants during development,
   // but does not affect the production build.
   <React.StrictMode>
-    {/* 
-      The <App /> component is the root component of the React application.
-      It serves as the main entry point for the UI, managing the overall structure and routing.
-    */}
-    <App />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/rule/:ruleName" element={<RuleDetailPage />} />
+        <Route path="*" element={<App />} />
+      </Routes>
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add React Router and route definitions
- create dedicated RuleDetailPage
- disable mouse zoom in TrendChart and add zoom buttons
- open RuleDetailPage when clicking a line chart dataset

## Testing
- `./run_tests.sh` *(fails: docker-compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1660c8883319cf2e1ac782beea5