### PR TITLE
Add rule filter for dashboard results

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -319,6 +319,12 @@ def get_rule_by_name(rule_name: str, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Rule not found")
     return rule
 
+
+@app.get("/api/db-connections/{connection_id}/rules", response_model=List[str])
+def list_rule_names(connection_id: UUID, db: Session = Depends(get_db)):
+    """Return all rule names for a given connection."""
+    return crud.get_rule_names(db, connection_id)
+
 @app.get("/api/dashboard/kpis", response_model=DashboardKPI)
 def dashboard_kpis(
     db_conn_id: UUID = Query(..., alias="db_conn_id"),
@@ -389,10 +395,11 @@ def dashboard_results(
     date_from: datetime.date | None = Query(None),
     date_to: datetime.date | None = Query(None),
     limit: int = Query(100),
+    rules: List[str] | None = Query(None),
     db: Session = Depends(get_db),
 ):
     """Return recent rule results for a connection."""
-    return get_dashboard_results(db, db_conn_id, date_from, date_to, limit)
+    return get_dashboard_results(db, db_conn_id, date_from, date_to, limit, rules)
 
 @app.websocket("/ws/chat")
 async def chat_ws(websocket: WebSocket):

--- a/frontend/src/components/dashboard/RuleResultsTable.tsx
+++ b/frontend/src/components/dashboard/RuleResultsTable.tsx
@@ -1,12 +1,26 @@
 import React from 'react';
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Autocomplete, TextField } from '@mui/material';
 import type { DashboardResultItem } from '../../types';
 
-interface Props { results: DashboardResultItem[]; }
+interface Props {
+  results: DashboardResultItem[];
+  allRules: string[];
+  selectedRules: string[];
+  onSelectedRulesChange: (v: string[]) => void;
+}
 
-const RuleResultsTable: React.FC<Props> = ({ results }) => (
+const RuleResultsTable: React.FC<Props> = ({ results, allRules, selectedRules, onSelectedRulesChange }) => (
   <div>
     <h3 className="text-xl font-semibold mb-2">Latest Rule Results</h3>
+    <Autocomplete
+      multiple
+      size="small"
+      options={allRules}
+      value={selectedRules}
+      onChange={(_, v) => onSelectedRulesChange(v as string[])}
+      renderInput={(params) => <TextField {...params} label="Filter rules" placeholder="All" />}
+      sx={{ mb: 1, width: 300 }}
+    />
     <TableContainer component={Paper}>
       <Table size="small">
         <TableHead>


### PR DESCRIPTION
## Summary
- add query support for filtering dashboard results by rule name
- expose endpoint to list rule names by connection
- fetch rule list on dashboard and support multi-select filtering
- display rule filter dropdown in results table

## Testing
- `./infra/start-tests.sh --skip-frontend`
- `./infra/start-tests.sh --skip-backend`
- `./infra/start-tests.sh`
