### PR TITLE
Fix pagination overlay

### DIFF
--- a/frontend/src/components/dashboard/RuleResultsTable.tsx
+++ b/frontend/src/components/dashboard/RuleResultsTable.tsx
@@ -82,8 +82,11 @@ const RuleResultsTable: React.FC<Props> = ({
           page={page}
           onPageChange={(_, p) => onPageChange(p)}
           rowsPerPage={rowsPerPage}
-          onRowsPerPageChange={e => onRowsPerPageChange(parseInt(e.target.value, 10))}
+          onRowsPerPageChange={e =>
+            onRowsPerPageChange(parseInt(e.target.value, 10))
+          }
           rowsPerPageOptions={[5, 10, 25]}
+          sx={{ pb: 8 }}
         />
       </TableContainer>
     </div>


### PR DESCRIPTION
## Summary
- prevent `ChatWidget` from hiding pagination controls by adding padding
