### PR TITLE
Fix overlapping pagination

### DIFF
--- a/frontend/src/components/dashboard/RuleResultsTable.tsx
+++ b/frontend/src/components/dashboard/RuleResultsTable.tsx
@@ -86,7 +86,12 @@ const RuleResultsTable: React.FC<Props> = ({
             onRowsPerPageChange(parseInt(e.target.value, 10))
           }
           rowsPerPageOptions={[5, 10, 25]}
-          sx={{ pb: 50 }}
+          sx={{
+            pb: 50,
+            '& .MuiTablePagination-toolbar': {
+              justifyContent: 'flex-start'
+            }
+          }}
         />
       </TableContainer>
     </div>


### PR DESCRIPTION
## Summary
- left-align pagination controls so they don't overlap with the chat button

## Testing
- `npx jest` *(fails: interactive prompt to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_686bd2005fb88331a7f478f972c9d385