### PR TITLE
Fix missing session endpoint and use card design

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -170,3 +170,8 @@ class DashboardResultPage(BaseModel):
     """Paged list of DashboardResultItem objects."""
     total: int
     items: List[DashboardResultItem]
+
+
+class SessionResponse(BaseModel):
+    """Simple session identifier returned by ``/api/session``."""
+    session_id: str

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,7 +22,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import Session
 from typing import List
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import logging
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ from app.crud import (
 from app.models import DBConnection, ColumnRule
 from app import crud, schemas
 from app.database import get_db
-from app.schemas import ConnectionTestRequest, ConnectionTestResponse
+from app.schemas import ConnectionTestRequest, ConnectionTestResponse, SessionResponse
 from app.schemas import (
     DashboardKPI,
     DashboardTrendItem,
@@ -90,6 +90,12 @@ async def query_llm(prompt: str) -> str:
         resp.raise_for_status()
         data = resp.json()
     return data.get("response", "")
+
+
+@app.post("/api/session", response_model=schemas.SessionResponse)
+def create_session() -> schemas.SessionResponse:
+    """Return a new session identifier for the client."""
+    return schemas.SessionResponse(session_id=str(uuid4()))
 
 @app.post("/api/test-connection", response_model=ConnectionTestResponse)
 def test_connection(req: ConnectionTestRequest):

--- a/backend/tests/test_session_endpoint.py
+++ b/backend/tests/test_session_endpoint.py
@@ -1,0 +1,19 @@
+"""Tests for the ``/api/session`` endpoint."""
+
+import sys
+import os
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from main import app
+
+
+def test_create_session_returns_id():
+    client = TestClient(app)
+    resp = client.post("/api/session")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "session_id" in data
+    assert isinstance(data["session_id"], str)
+

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -7,7 +7,8 @@
 import React, { useState, useRef, useEffect, FormEvent } from 'react';
 import {
   Box,
-  Paper,
+  Card,
+  CardContent,
   Typography,
   Collapse,
   Divider,
@@ -403,42 +404,44 @@ const ChatWidget: React.FC<ChatWidgetProps> = ({ connectionId }) => {
           color: theme.palette.primary.contrastText,
         })
       }}>
-        <Paper elevation={4} sx={{ borderRadius: '16px' }}>
-          {/* Header component with controls to open/close the chat */}
-          <ChatHeader
-            expanded={expanded}
-            onOpen={() => setExpanded(true)}
-            onClose={() => setExpanded(false)}
-          />
-          {/* Collapse component to show/hide chat content */}
-          <Collapse in={expanded}>
-            {/* Chat history showing all messages and loading indicator */}
-            <ChatHistory
-              messages={messages}
-              loading={loading}
-              historyRef={historyRef}
+        <Card sx={{ borderRadius: '16px', boxShadow: 4 }}>
+          <CardContent>
+            {/* Header component with controls to open/close the chat */}
+            <ChatHeader
+              expanded={expanded}
+              onOpen={() => setExpanded(true)}
+              onClose={() => setExpanded(false)}
             />
-            {/* Chat input form with various props for interaction */}
-            <ChatForm
-              input={input}
-              onInputChange={e => setInput(e.target.value)}
-              onSubmit={handleSend}
-              ruleCreation={ruleCreation}
-              selectedColumns={selectedColumns}
-              onRemoveColumn={(column) => {
-                // Remove a selected column from the set when requested.
-                setSelectedColumns(prev => {
-                  const next = new Set(prev);
-                  next.delete(column);
-                  return next;
-                });
-              }}
-              onToggleRuleCreation={checked => setRuleCreation(checked)}
-              onOpenColumns={() => setColumnModalOpen(true)}
-              onOpenChat={() => setExpanded(true)}
-            />
-          </Collapse>
-        </Paper>
+            {/* Collapse component to show/hide chat content */}
+            <Collapse in={expanded}>
+              {/* Chat history showing all messages and loading indicator */}
+              <ChatHistory
+                messages={messages}
+                loading={loading}
+                historyRef={historyRef}
+              />
+              {/* Chat input form with various props for interaction */}
+              <ChatForm
+                input={input}
+                onInputChange={e => setInput(e.target.value)}
+                onSubmit={handleSend}
+                ruleCreation={ruleCreation}
+                selectedColumns={selectedColumns}
+                onRemoveColumn={(column) => {
+                  // Remove a selected column from the set when requested.
+                  setSelectedColumns(prev => {
+                    const next = new Set(prev);
+                    next.delete(column);
+                    return next;
+                  });
+                }}
+                onToggleRuleCreation={checked => setRuleCreation(checked)}
+                onOpenColumns={() => setColumnModalOpen(true)}
+                onOpenChat={() => setExpanded(true)}
+              />
+            </Collapse>
+          </CardContent>
+        </Card>
         {/* Modal dialog for selecting which columns to include in prompts */}
         <IncludeColumnsModal
           open={columnModalOpen}


### PR DESCRIPTION
## Summary
- implement `/api/session` endpoint returning a session id
- add test for the new endpoint
- switch ChatWidget container from `Paper` to `Card`
