### PR TITLE
Add SwiftUI iOS example

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "LumaIOS",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(name: "LumaIOS", targets: ["LumaIOS"])
+    ],
+    targets: [
+        .target(
+            name: "LumaIOS",
+            path: "Sources/LumaIOS",
+            resources: [
+                .process("Data/MockRules.json")
+            ]
+        ),
+        .testTarget(
+            name: "LumaIOSTests",
+            dependencies: ["LumaIOS"],
+            path: "Tests"
+        )
+    ]
+)

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,13 @@
+# Luma iOS Example
+
+This directory contains a minimal SwiftUI application for **Luma** using mocked data. The app lists sample validation rules and displays their details.
+
+## Structure
+- `Package.swift` – Swift Package manifest describing the app.
+- `Sources/LumaIOS` – SwiftUI source files and mocked data.
+- `Tests` – Basic unit test verifying mock data loading.
+
+## Running
+Open this folder in Xcode 15 or later and build the `LumaIOS` target.
+
+The project uses a JSON file `MockRules.json` bundled as a resource to provide mock rules. The `RuleListViewModel` loads this data on startup.

--- a/ios/Sources/LumaIOS/Data/MockRules.json
+++ b/ios/Sources/LumaIOS/Data/MockRules.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "11111111-1111-1111-1111-111111111111",
+    "title": "Sample Rule A",
+    "description": "Sample description A"
+  },
+  {
+    "id": "22222222-2222-2222-2222-222222222222",
+    "title": "Sample Rule B",
+    "description": "Sample description B"
+  }
+]

--- a/ios/Sources/LumaIOS/LumaIOSApp.swift
+++ b/ios/Sources/LumaIOS/LumaIOSApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct LumaIOSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            RuleListView(viewModel: RuleListViewModel())
+        }
+    }
+}

--- a/ios/Sources/LumaIOS/Models/Rule.swift
+++ b/ios/Sources/LumaIOS/Models/Rule.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Rule: Identifiable, Decodable {
+    let id: UUID
+    let title: String
+    let description: String
+}

--- a/ios/Sources/LumaIOS/ViewModels/RuleListViewModel.swift
+++ b/ios/Sources/LumaIOS/ViewModels/RuleListViewModel.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Combine
+
+final class RuleListViewModel: ObservableObject {
+    @Published var rules: [Rule] = []
+
+    init() {
+        loadMockData()
+    }
+
+    private func loadMockData() {
+        if let url = Bundle.module.url(forResource: "MockRules", withExtension: "json"),
+           let data = try? Data(contentsOf: url),
+           let loaded = try? JSONDecoder().decode([Rule].self, from: data) {
+            self.rules = loaded
+        } else {
+            self.rules = [
+                Rule(id: UUID(), title: "Mock Rule 1", description: "Ensure table orders has a primary key."),
+                Rule(id: UUID(), title: "Mock Rule 2", description: "Column email should not be empty.")
+            ]
+        }
+    }
+}

--- a/ios/Sources/LumaIOS/Views/RuleDetailView.swift
+++ b/ios/Sources/LumaIOS/Views/RuleDetailView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct RuleDetailView: View {
+    let rule: Rule
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(rule.title)
+                .font(.title)
+            Text(rule.description)
+            Spacer()
+        }
+        .padding()
+        .navigationTitle("Detail")
+    }
+}
+
+struct RuleDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        RuleDetailView(rule: Rule(id: UUID(), title: "Rule", description: "Description"))
+    }
+}

--- a/ios/Sources/LumaIOS/Views/RuleListView.swift
+++ b/ios/Sources/LumaIOS/Views/RuleListView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct RuleListView: View {
+    @ObservedObject var viewModel: RuleListViewModel
+
+    var body: some View {
+        NavigationView {
+            List(viewModel.rules) { rule in
+                NavigationLink(destination: RuleDetailView(rule: rule)) {
+                    Text(rule.title)
+                }
+            }
+            .navigationTitle("Luma Rules")
+        }
+    }
+}
+
+struct RuleListView_Previews: PreviewProvider {
+    static var previews: some View {
+        RuleListView(viewModel: RuleListViewModel())
+    }
+}

--- a/ios/Tests/LumaIOSTests.swift
+++ b/ios/Tests/LumaIOSTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import LumaIOS
+
+final class LumaIOSTests: XCTestCase {
+    func testLoadMockData() {
+        let viewModel = RuleListViewModel()
+        XCTAssertFalse(viewModel.rules.isEmpty, "Rules should load from mock data")
+    }
+}


### PR DESCRIPTION
## Summary
- add `LumaIOS` Swift Package with mocked rule data
- include SwiftUI views, view model, and test

## Testing
- `./run_tests.sh` *(fails: `docker-compose: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687fd3ca04288331ae704806368010eb