### PR TITLE
Rename product to QuaChat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/thiwi/valiax/compare/v0.2.1...HEAD)
+## [Unreleased](https://github.com/thiwi/quachat/compare/v0.2.1...HEAD)
 
-## [v0.2.1](https://github.com/thiwi/valiax/compare/v0.2.0...v0.2.1) - 2025-05-25
+## [v0.2.1](https://github.com/thiwi/quachat/compare/v0.2.0...v0.2.1) - 2025-05-25
 
 ### Commits
 
-- switched from kubernetes-native runner to a custom [`2ba0fa7`](https://github.com/thiwi/valiax/commit/2ba0fa7c7bdb5e6f189cb310fb6c7e465554530f)
-- tag version [`24038d7`](https://github.com/thiwi/valiax/commit/24038d78d2aed8279a5a9d6352492d7c53b3f341)
+- switched from kubernetes-native runner to a custom [`2ba0fa7`](https://github.com/thiwi/quachat/commit/2ba0fa7c7bdb5e6f189cb310fb6c7e465554530f)
+- tag version [`24038d7`](https://github.com/thiwi/quachat/commit/24038d78d2aed8279a5a9d6352492d7c53b3f341)
 
 ## v0.2.0 - 2025-05-23
 
 ### Commits
 
-- initial [`3eee08d`](https://github.com/thiwi/valiax/commit/3eee08dad3c91e4f1f38d8099c710da24bbd6c0d)
-- added tests [`8ca8a1b`](https://github.com/thiwi/valiax/commit/8ca8a1b28ed08d34f22aa3daeeb9e40953f8d250)
-- chore(k8s): migrate test infrastructure from Docker-Compose to Kubernetes [`2746562`](https://github.com/thiwi/valiax/commit/27465620b77b464ea0ef824ed442636f3da6b77c)
+- initial [`3eee08d`](https://github.com/thiwi/quachat/commit/3eee08dad3c91e4f1f38d8099c710da24bbd6c0d)
+- added tests [`8ca8a1b`](https://github.com/thiwi/quachat/commit/8ca8a1b28ed08d34f22aa3daeeb9e40953f8d250)
+- chore(k8s): migrate test infrastructure from Docker-Compose to Kubernetes [`2746562`](https://github.com/thiwi/quachat/commit/27465620b77b464ea0ef824ed442636f3da6b77c)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <img width="300px" src="https://github.com/user-attachments/assets/ea1d1dda-b820-4485-8263-e5799ced27a8" />
 
-# Valiax
+# QuaChat
 
 *Data Quality Intelligence. In a Simple Conversation.*
 
-Valiax is a local-first platform for conversational data quality governance. It lets you define, version, execute and monitor validation rules using natural language. Ideal for data engineers, analysts, and stewards who want to bridge business intent and technical validation — without writing complex SQL or Python manually.
+QuaChat is a local-first platform for conversational data quality governance. It lets you define, version, execute and monitor validation rules using natural language. Ideal for data engineers, analysts, and stewards who want to bridge business intent and technical validation — without writing complex SQL or Python manually.
 
-*Version 1.0. See the <a href="https://github.com/thiwi/valiax/wiki">Wiki</a> for more information.*
+*Version 1.0. See the <a href="https://github.com/thiwi/quachat/wiki">Wiki</a> for more information.*
 
 ---
 

--- a/additional_info.txt
+++ b/additional_info.txt
@@ -3,8 +3,8 @@ Test db connection in modal (running local) with: postgresql://ecom_user:secret@
 
 
 Port forwarding on mac:
-kubectl port-forward service/frontend 3000:3000 -n valiax
+kubectl port-forward service/frontend 3000:3000 -n quachat
 kubectl port-forward svc/backend 8000:8000
 
-kubectl exec -n valiax -it postgres-bf54d84f7-dsr2j -- bash
-psql -U user -d Valiax
+kubectl exec -n quachat -it postgres-bf54d84f7-dsr2j -- bash
+psql -U user -d QuaChat

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,4 +1,4 @@
 """
-Backend package for the Valiax application.
+Backend package for the QuaChat application.
 Contains the API, database models, and utilities.
 """

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 """
-Subpackage holding database models and CRUD logic for Valiax.
+Subpackage holding database models and CRUD logic for QuaChat.
 """

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,4 +1,4 @@
-"""CRUD helper functions for the Valiax backend."""
+"""CRUD helper functions for the QuaChat backend."""
 
 from sqlalchemy.orm import Session
 from . import models, schemas

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,4 +1,4 @@
-"""Database engine and session management for the Valiax backend."""
+"""Database engine and session management for the QuaChat backend."""
 
 import os
 from dotenv import load_dotenv
@@ -19,7 +19,7 @@ DB_USER = os.getenv("DB_USER", "user")  # Database username, default is 'user'
 DB_PASSWORD = os.getenv("DB_PASSWORD", "password")  # Database password, default is 'password'
 DB_HOST = os.getenv("DB_HOST", "postgres")  # Database host address, default is 'postgres' (service name)
 DB_PORT = os.getenv("DB_PORT", "5432")  # Database port, default PostgreSQL port is 5432
-DB_NAME = os.getenv("DB_NAME", "Valiax")  # Database name, default is 'Valiax'
+DB_NAME = os.getenv("DB_NAME", "QuaChat")  # Database name, default is 'QuaChat'
 
 # Construct the full database URL string used by SQLAlchemy to connect to the database.
 # If DATABASE_URL is set, it overrides the constructed URL.

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-"""SQLAlchemy ORM models used by the Valiax backend."""
+"""SQLAlchemy ORM models used by the QuaChat backend."""
 
 import uuid
 from sqlalchemy import Column, String, Text, ForeignKey, DateTime, JSON, Integer, Boolean

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,7 @@
 """
 main.py
 
-This is the main FastAPI application for the Valiax backend. It provides a REST API and WebSocket endpoints
+This is the main FastAPI application for the QuaChat backend. It provides a REST API and WebSocket endpoints
 for managing database connections, inspecting tables and columns, managing data quality rules, and interacting
 with a language model (LLM) microservice for chat functionality.
 

--- a/backend/tests/test_additional.py
+++ b/backend/tests/test_additional.py
@@ -1,4 +1,4 @@
-"""Additional unit tests for the Valiax backend."""
+"""Additional unit tests for the QuaChat backend."""
 
 import importlib
 import sys

--- a/backend/tests/test_models_schemas_mocked.py
+++ b/backend/tests/test_models_schemas_mocked.py
@@ -12,7 +12,7 @@ import sys
 import os
 
 # Mock the database module to avoid actual database connections
-sys.path.insert(0, '/home/ubuntu/valiax_tests/backend')
+sys.path.insert(0, '/home/ubuntu/quachat_tests/backend')
 
 # Create mock modules
 class MockBase:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "Valiax-frontend",
+  "name": "QuaChat-frontend",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "Valiax-frontend",
+      "name": "QuaChat-frontend",
       "version": "1.0.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Valiax-frontend",
+  "name": "QuaChat-frontend",
   "version": "1.0.0",
   "private": true,
   "dependencies": {

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Valiax Frontend</title>
+  <title>QuaChat Frontend</title>
 </head>
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-    "short_name": "Valiax",
-    "name": "Valiax App",
+    "short_name": "QuaChat",
+    "name": "QuaChat App",
     "icons": [
       {
         "src": "favicon.ico",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 // src/App.tsx
 /**
  * The main application component that serves as the central layout and integration point
- * for all UI elements and state management within the Valiax frontend.
+ * for all UI elements and state management within the QuaChat frontend.
  * 
  * It manages database connections, table and column selections, rule creation,
  * and integrates the chat widget. It also handles modals and drawers for database
@@ -195,7 +195,7 @@ export default function App() {
         <Toolbar>
           {/* Application title */}
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-            Valiax
+            QuaChat
           </Typography>
           {/* Button to toggle database connections drawer */}
           <Button color="inherit" onClick={toggleNav}>

--- a/frontend/src/components/chat/ChatHeader.tsx
+++ b/frontend/src/components/chat/ChatHeader.tsx
@@ -46,7 +46,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({ expanded, onOpen, onClose }) =>
           textAlign: 'center',
         }}
       >
-        <Typography variant="subtitle1">Chat with Valiax</Typography>
+        <Typography variant="subtitle1">Chat with QuaChat</Typography>
         {expanded && (
           // IconButton: displays a close ("X") icon in the header when expanded.
           // Clicking this button triggers the onClose callback to collapse the chat.

--- a/frontend/src/components/chat/ChatHistory.tsx
+++ b/frontend/src/components/chat/ChatHistory.tsx
@@ -41,8 +41,8 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({ messages, loading, historyRef
             <ListItemText
               // Display the message text
               primary={msg.text}
-              // Display sender label: 'You' for user, 'Valiax' for bot
-              secondary={msg.from === 'user' ? 'You' : 'Valiax'}
+              // Display sender label: 'You' for user, 'QuaChat' for bot
+              secondary={msg.from === 'user' ? 'You' : 'QuaChat'}
               // Align message text right if from user, left if from bot
               primaryTypographyProps={{ align: msg.from === 'user' ? 'right' : 'left' }}
               // Use caption style for the sender label
@@ -58,7 +58,7 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({ messages, loading, historyRef
     {loading && (
       <Box sx={{ textAlign: 'center', mt: 1 }}>
         <CircularProgress size={20} />
-        <Typography variant="caption">Valiax is typing...</Typography>
+        <Typography variant="caption">QuaChat is typing...</Typography>
       </Box>
     )}
   </Box>

--- a/infra/deployment.yml
+++ b/infra/deployment.yml
@@ -1,14 +1,14 @@
-# deployment.yml: Kubernetes resources for Valiax application, including
+# deployment.yml: Kubernetes resources for QuaChat application, including
 # database PVCs, backend, rule-runner, Celery infrastructure, and frontend.
 
 ---
-# Postgres data volume claim for Valiax metadata database
+# Postgres data volume claim for QuaChat metadata database
 # PersistentVolumeClaims for Postgres and the two ecommerce DBs
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: pgdata
-  namespace: valiax
+  namespace: quachat
 spec:
   accessModes:
     - ReadWriteOnce
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ecommerce-data1
-  namespace: valiax
+  namespace: quachat
 spec:
   accessModes:
     - ReadWriteOnce
@@ -36,7 +36,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ecommerce-data2
-  namespace: valiax
+  namespace: quachat
 spec:
   accessModes:
     - ReadWriteOnce
@@ -45,13 +45,13 @@ spec:
       storage: 1Gi
 
 ---
-# PostgreSQL deployment for main Valiax metadata store
-# Postgres (Valiax)
+# PostgreSQL deployment for main QuaChat metadata store
+# Postgres (QuaChat)
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: postgres
-  namespace: valiax
+  namespace: quachat
 spec:
   replicas: 1
   selector:
@@ -67,7 +67,7 @@ spec:
         image: postgres:15
         env:
         - name: POSTGRES_DB
-          value: "Valiax"
+          value: "QuaChat"
         - name: POSTGRES_USER
           value: "user"
         - name: POSTGRES_PASSWORD
@@ -91,7 +91,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgres
-  namespace: valiax
+  namespace: quachat
 spec:
   selector: { app: postgres }
   ports:
@@ -106,7 +106,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis
-  namespace: valiax
+  namespace: quachat
 spec:
   replicas: 1
   selector:
@@ -127,7 +127,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis
-  namespace: valiax
+  namespace: quachat
 spec:
   selector: { app: redis }
   ports:
@@ -136,13 +136,13 @@ spec:
     targetPort: 6379
 
 ---
-# Backend API deployment for Valiax, handles rule definitions and results
+# Backend API deployment for QuaChat, handles rule definitions and results
 # Backend
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: backend
-  namespace: valiax
+  namespace: quachat
 spec:
   replicas: 1
   selector:
@@ -159,7 +159,7 @@ spec:
         imagePullPolicy: IfNotPresent
         env:
         - name: DATABASE_URL
-          value: postgresql://user:password@postgres:5432/Valiax
+          value: postgresql://user:password@postgres:5432/QuaChat
         ports:
         - containerPort: 8000
 
@@ -169,7 +169,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: backend
-  namespace: valiax
+  namespace: quachat
 spec:
   selector: { app: backend }
   ports:
@@ -183,7 +183,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: llm-service
-  namespace: valiax
+  namespace: quachat
 spec:
   replicas: 1
   selector:
@@ -206,7 +206,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: llm-service
-  namespace: valiax
+  namespace: quachat
 spec:
   selector: { app: llm-service }
   ports:
@@ -221,7 +221,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: worker
-  namespace: valiax
+  namespace: quachat
 spec:
   replicas: 1
   selector:
@@ -238,9 +238,9 @@ spec:
         - name: CELERY_BROKER_URL
           value: redis://redis:6379/0
         - name: DATABASE_URL
-          value: postgresql://user:password@postgres:5432/Valiax
+          value: postgresql://user:password@postgres:5432/QuaChat
         - name: RULE_RUNNER_URL
-          value: http://rule-runner.valiax.svc.cluster.local/run
+          value: http://rule-runner.quachat.svc.cluster.local/run
         command: ["celery", "-A", "worker", "worker", "--loglevel=info"]
 
 ---
@@ -250,7 +250,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: celery-beat
-  namespace: valiax
+  namespace: quachat
 spec:
   replicas: 1
   selector:
@@ -269,7 +269,7 @@ spec:
         - name: CELERY_BROKER_URL
           value: redis://redis:6379/0
         - name: DATABASE_URL
-          value: postgresql://user:password@postgres:5432/Valiax
+          value: postgresql://user:password@postgres:5432/QuaChat
         command: ["celery", "-A", "worker", "beat", "--loglevel=info"]
 
 ---
@@ -278,7 +278,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: worker
-  namespace: valiax
+  namespace: quachat
 spec:
   selector: { app: worker }
   ports:
@@ -294,7 +294,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rule-runner
-  namespace: valiax
+  namespace: quachat
 spec:
   replicas: 1
   selector:
@@ -311,7 +311,7 @@ spec:
         imagePullPolicy: IfNotPresent
         env:
         - name: MAIN_DB_URL
-          value: postgresql://user:password@postgres:5432/Valiax
+          value: postgresql://user:password@postgres:5432/QuaChat
         ports:
         - containerPort: 80
 ---
@@ -321,7 +321,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: rule-runner
-  namespace: valiax
+  namespace: quachat
 spec:
   selector:
     app: rule-runner
@@ -332,13 +332,13 @@ spec:
 
 
 ---
-# Frontend deployment: React application for Valiax UI
+# Frontend deployment: React application for QuaChat UI
 # Frontend
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
-  namespace: valiax
+  namespace: quachat
 spec:
   replicas: 1
   selector:
@@ -363,7 +363,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: frontend
-  namespace: valiax
+  namespace: quachat
 spec:
   type: NodePort
   selector: { app: frontend }
@@ -380,7 +380,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ecommerce-db-1
-  namespace: valiax
+  namespace: quachat
 spec:
   replicas: 1
   selector:
@@ -422,7 +422,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ecommerce-db-1
-  namespace: valiax
+  namespace: quachat
 spec:
   selector: { app: ecommerce-db-1 }
   ports:
@@ -438,7 +438,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ecommerce-db-2
-  namespace: valiax
+  namespace: quachat
 spec:
   replicas: 1
   selector:
@@ -480,7 +480,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ecommerce-db-2
-  namespace: valiax
+  namespace: quachat
 spec:
   selector: { app: ecommerce-db-2 }
   ports:

--- a/infra/docker-compose.test.yml
+++ b/infra/docker-compose.test.yml
@@ -2,7 +2,7 @@ services:
   postgres:
     image: postgres:15
     environment:
-      POSTGRES_DB: valiax_test
+      POSTGRES_DB: quachat_test
       POSTGRES_USER: user
       POSTGRES_PASSWORD: password
     ports:
@@ -13,7 +13,7 @@ services:
       context: ../backend
       dockerfile: Dockerfile.test
     environment:
-      DATABASE_URL: postgresql://user:password@postgres:5432/valiax_test
+      DATABASE_URL: postgresql://user:password@postgres:5432/quachat_test
     command: ["pytest", "tests/"]
     volumes:
       - ../backend:/app

--- a/infra/start-minikube.sh
+++ b/infra/start-minikube.sh
@@ -1,5 +1,5 @@
 # start-minikube.sh: Script to set up a local Minikube cluster, build Docker images,
-# load them into Minikube, and deploy the Valiax application stack into the ‘valiax’ namespace.
+# load them into Minikube, and deploy the QuaChat application stack into the ‘quachat’ namespace.
 #!/bin/bash
 
 # Exit immediately if any command fails (non-zero exit)
@@ -20,10 +20,10 @@ echo "🚀 Starting Minikube..."
 # Start Minikube with Docker driver and allocate CPU/memory resources
 minikube start --driver=docker --cpus=4 --memory=4096
 
-# Configure kubectl to target the Minikube cluster and use the ‘valiax’ namespace
+# Configure kubectl to target the Minikube cluster and use the ‘quachat’ namespace
 kubectl config use-context minikube
-kubectl create namespace valiax || true
-kubectl config set-context --current --namespace=valiax
+kubectl create namespace quachat || true
+kubectl config set-context --current --namespace=quachat
 
 
 # Build local Docker images for components and load them into Minikube’s Docker daemon
@@ -53,15 +53,15 @@ echo "📑 Creating ConfigMap for ecommerce init scripts…"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # One configmap per ecommerce database to allow individual initialization
-kubectl delete configmap ecommerce-init-1 -n valiax --ignore-not-found
+kubectl delete configmap ecommerce-init-1 -n quachat --ignore-not-found
 kubectl create configmap ecommerce-init-1 \
   --from-file=init.sql="$REPO_ROOT/ecommerce-init-1/init.sql" \
-  -n valiax
+  -n quachat
 
-kubectl delete configmap ecommerce-init-2 -n valiax --ignore-not-found
+kubectl delete configmap ecommerce-init-2 -n quachat --ignore-not-found
 kubectl create configmap ecommerce-init-2 \
   --from-file=init.sql="$REPO_ROOT/ecommerce-init-2/init.sql" \
-  -n valiax
+  -n quachat
 
 # Create or update ConfigMap for backend initialization scripts
 echo "📑 Creating ConfigMap for init scripts…"
@@ -87,7 +87,7 @@ nohup kubectl port-forward svc/backend 8000:8000 >/dev/null 2>&1 &
 # Notify user that the frontend is being opened in the default browser
 echo "🌐 Opening frontend in browser..."
 # Query the NodePort assigned to the frontend service and compose the URL
-NODE_PORT=$(kubectl get svc frontend -n valiax -o jsonpath='{.spec.ports[0].nodePort}')
+NODE_PORT=$(kubectl get svc frontend -n quachat -o jsonpath='{.spec.ports[0].nodePort}')
 MINIKUBE_IP=$(minikube ip)
 FRONTEND_URL="http://${MINIKUBE_IP}:${NODE_PORT}"
 echo "🌐 Frontend accessible at: $FRONTEND_URL"

--- a/infra/stop-minikube.sh
+++ b/infra/stop-minikube.sh
@@ -7,10 +7,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Path to the Kubernetes manifests file
 DEPLOYMENT_FILE="$SCRIPT_DIR/deployment.yml"
 
-# Switch context to 'valiax' namespace for cleanup
-kubectl config set-context --current --namespace=valiax
+# Switch context to 'quachat' namespace for cleanup
+kubectl config set-context --current --namespace=quachat
 
-echo "🛑 Stopping Valiax environment..."
+echo "🛑 Stopping QuaChat environment..."
 
 echo "🗑️ Deleting Kubernetes deployments and services..."
 kubectl delete -f "$DEPLOYMENT_FILE" || true
@@ -21,7 +21,7 @@ minikube image rm backend:latest || true
 minikube image rm worker:latest || true
 
 echo "🗑️ Deleting Kubernetes PersistentVolumeClaims and PersistentVolumes..."
-kubectl delete pvc --all --namespace valiax || true
+kubectl delete pvc --all --namespace quachat || true
 kubectl delete pv --all || true
 
 echo "🗑️ Deleting Docker volumes inside Minikube..."

--- a/infra/test-jobs.yml
+++ b/infra/test-jobs.yml
@@ -30,7 +30,7 @@ spec:
             && pytest -v --maxfail=1 --disable-warnings --junitxml=/reports/backend-results.xml
         env:
         - name: DATABASE_URL
-          value: postgresql://user:password@localhost:5432/valiax_test
+          value: postgresql://user:password@localhost:5432/quachat_test
         volumeMounts:
         - name: postgres-data
           mountPath: /var/lib/postgresql/data
@@ -46,7 +46,7 @@ spec:
         - name: POSTGRES_PASSWORD
           value: "password"
         - name: POSTGRES_DB
-          value: "valiax_test"
+          value: "quachat_test"
         volumeMounts:
         - name: postgres-data
           mountPath: /var/lib/postgresql/data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "valiax",
+  "name": "quachat",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-# valiax/worker/Dockerfile
+# quachat/worker/Dockerfile
 FROM python:3.11-slim
 
 WORKDIR /app

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -84,7 +84,7 @@ def check_rules():
     cur.close()
     conn.close()
 
-    runner_url = os.getenv("RULE_RUNNER_URL", "http://rule-runner.valiax.svc.cluster.local/run")
+    runner_url = os.getenv("RULE_RUNNER_URL", "http://rule-runner.quachat.svc.cluster.local/run")
 
     # Send an HTTP POST for each due rule to the external rule-runner service
     for rule_id in due_rules:


### PR DESCRIPTION
### Motivation
- Standardize the product name across the repository by replacing all occurrences of "Valiax"/"valiax"/"Valiax" with "QuaChat"/"quachat"/"QuaChat". 
- Align runtime defaults and Kubernetes resources so namespaces, database names, and service hostnames reflect the new product name. 
- Update UI, manifests and packaging metadata so the frontend and developer docs show the new brand.

### Description
- Replaced product name in documentation and metadata, including `README.md`, `CHANGELOG.md`, `additional_info.txt`, and package lock files. 
- Updated backend comments and defaults such as `DB_NAME` in `backend/app/database.py` and docstrings to reference QuaChat. 
- Updated frontend package names and UI text (App title, chat header/history messages), `frontend/package.json`, `frontend/public/index.html`, and `frontend/public/manifest.json`. 
- Adjusted infra manifests and scripts to use `quachat` namespace and `QuaChat` database/service names (`infra/deployment.yml`, `infra/start-minikube.sh`, `infra/stop-minikube.sh`, `infra/docker-compose.test.yml`, `infra/test-jobs.yml`). 
- Updated runtime references in worker and other components (e.g., `worker/worker.py` `RULE_RUNNER_URL`) and test path strings in tests to match the new project name.

### Testing
- Ran `npm install --legacy-peer-deps` in `frontend` which completed successfully and installed dependencies. 
- Started the frontend with `npm start` and observed a successful compile and dev server startup (webpack compiled successfully). 
- Captured a screenshot of the running frontend using a Playwright script which produced `artifacts/quachat-ui.png`. 
- No automated backend unit test suite was executed as part of this rename change; proxy errors were observed when the frontend attempted API requests because the backend service was not running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dd52d174c833188cc6c8f619df04c)